### PR TITLE
Update generate_sg.py

### DIFF
--- a/src/generate_sg.py
+++ b/src/generate_sg.py
@@ -282,7 +282,8 @@ def main():
     # Create EMA for the sg2sc model
     ema_config = config["training"]["ema"]
     if ema_config["use_ema"]:
-        sg2sc_ema_states = EMAModel(model.parameters())
+        # sg2sc_ema_states = EMAModel(model.parameters())
+        sg2sc_ema_states = EMAModel(sg2c_model.parameters())
         sg2sc_ema_states.to(device)
     else:
         sg2sc_ema_states: EMAModel = None


### PR DESCRIPTION
While copying ema_states to sg2c_model it is giving error due to incompatible shapes. This is because while generating scene graph, ema_states is made for model which is a SgObjfeatVQDiffusion model, but while copying ema_state we are doing sg2sc_ema_states.copy_to(sg2sc_model.parameters()), where, sg2c_model is a Sg2CDiffusion model. So, I thought this was the reason for error, and I replaced sg2sc_ema_states = EMAModel(model.parameters()) with, sg2sc_ema_states = EMAModel(sg2sc_model.parameters()), and right now, there is no error.